### PR TITLE
iOS7 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+,*
 .DS_Store
 Xcode/Pods
 Xcode/*.xcworkspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 **IMPORTANT: Version 0.y.z is for initial develpment. Anything may change at any time. The public API should not be considered stable.**
 
+## 0.3.0
+
+- Error propagation from onFulfill callback
+- Fix iOS7 compatibility issues
+
 ## 0.2.1
 
 - Update Podfile.lock

--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+import Foundation
+
 private enum PromiseState<T>: CustomStringConvertible {
     case Pending
     case Fulfilled(T)

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -57,7 +57,7 @@ class OnePromiseTests: XCTestCase {
 
                 return np
             })
-            .then(dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0), { (s) in
+            .then(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), { (s) in
                 XCTAssertEqual(s, "2000")
                 expectation.fulfill()
             })

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -326,7 +326,7 @@ extension OnePromiseTests {
             .then({ (i) throws -> Void in
                 throw SomeError.IntError(i)
             })
-            .then(nil, { (e:NSError) in
+            .then(nil, { (e: NSError) in
                 XCTAssertEqual(e.domain, "OnePromise_Tests.OnePromiseTests.SomeError")
                 expectation.fulfill()
             })
@@ -343,7 +343,7 @@ extension OnePromiseTests {
             .then({ (i) throws -> Void in
                 throw NSError(domain: "test.SomeError", code: 123, userInfo: nil)
             })
-            .then(nil, { (e:NSError) in
+            .then(nil, { (e: NSError) in
                 XCTAssertEqual(e.domain, "test.SomeError")
                 XCTAssertEqual(e.code, 123)
                 expectation.fulfill()
@@ -361,7 +361,7 @@ extension OnePromiseTests {
             .then({ (i) throws -> Promise<Int> in
                 throw NSError(domain: "test.SomeError", code: 123, userInfo: nil)
             })
-            .then(nil, { (e:NSError) in
+            .then(nil, { (e: NSError) in
                 XCTAssertEqual(e.domain, "test.SomeError")
                 XCTAssertEqual(e.code, 123)
                 expectation.fulfill()

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -1,6 +1,5 @@
 import UIKit
 import XCTest
-import OnePromise
 
 class OnePromiseTests: XCTestCase {
 

--- a/Xcode/FrameworkImportTests.swift
+++ b/Xcode/FrameworkImportTests.swift
@@ -1,0 +1,3 @@
+import XCTest
+import OnePromise
+class FrameworkImportTests: XCTestCase {}

--- a/Xcode/OnePromise.xcodeproj/project.pbxproj
+++ b/Xcode/OnePromise.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		5BC6C354E8479B49080BCCE7 /* Pods_OnePromise_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 70B5EA1356315F0B464FA4E3 /* Pods_OnePromise_Tests.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		607FACEC1AFB9204008FA782 /* OnePromiseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* OnePromiseTests.swift */; };
+		A5A1E6B81BD53564005CC35A /* OnePromise.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A1E6B71BD53564005CC35A /* OnePromise.swift */; settings = {ASSET_TAGS = (); }; };
+		A5A1E6BA1BD53595005CC35A /* FrameworkImportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A1E6B91BD53595005CC35A /* FrameworkImportTests.swift */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -16,6 +18,8 @@
 		607FACEA1AFB9204008FA782 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = SOURCE_ROOT; };
 		607FACEB1AFB9204008FA782 /* OnePromiseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = OnePromiseTests.swift; path = ../OnePromiseTests.swift; sourceTree = SOURCE_ROOT; };
 		70B5EA1356315F0B464FA4E3 /* Pods_OnePromise_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_OnePromise_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5A1E6B71BD53564005CC35A /* OnePromise.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = OnePromise.swift; path = ../OnePromise.swift; sourceTree = "<group>"; };
+		A5A1E6B91BD53595005CC35A /* FrameworkImportTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FrameworkImportTests.swift; sourceTree = "<group>"; };
 		D396C96D272ECFEA687D2682 /* Pods-OnePromise_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OnePromise_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-OnePromise_Tests/Pods-OnePromise_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		F072A273B04F4BACDF09FC34 /* Pods-OnePromise_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-OnePromise_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-OnePromise_Tests/Pods-OnePromise_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -35,7 +39,9 @@
 		607FACC71AFB9204008FA782 = {
 			isa = PBXGroup;
 			children = (
+				A5A1E6B71BD53564005CC35A /* OnePromise.swift */,
 				607FACEB1AFB9204008FA782 /* OnePromiseTests.swift */,
+				A5A1E6B91BD53595005CC35A /* FrameworkImportTests.swift */,
 				A573E2B71BD45F28008DF350 /* Support Files */,
 				607FACD11AFB9204008FA782 /* Products */,
 				A83AD5D9B3CAF14D1CE2DA2A /* Pods */,
@@ -195,7 +201,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5A1E6B81BD53564005CC35A /* OnePromise.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* OnePromiseTests.swift in Sources */,
+				A5A1E6BA1BD53595005CC35A /* FrameworkImportTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
- UnitTests should NOT `import` module. Dynamic lib is not supported by iOS7. So I include OnePromise*.swift files into the test project.
- Remove missing constant in iOS7 from test.
- Fixes some problems introduced in #4 
