### PR TITLE
Remove project dependant test

### DIFF
--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -343,7 +343,7 @@ extension OnePromiseTests {
                 throw SomeError.IntError(i)
             })
             .then(nil, { (e: NSError) in
-                XCTAssertEqual(e.domain, "OnePromise_Tests.OnePromiseTests.SomeError")
+                XCTAssertTrue(e.domain.hasSuffix(".OnePromiseTests.SomeError"))
                 expectation.fulfill()
             })
 


### PR DESCRIPTION
OnePromiseTest.swift includes comparison tests of NSError domain which prefixed with module name. The module name is usually product name, so these tests will be failed in other projects.

```
OnePromiseTests.swift: test failure: 
-[OnePromiseTests testPropagateSwiftErrorType()] failed: 
XCTAssertEqual failed: ("Optional("YOUR_PROJECT.OnePromiseTests.SomeError")") is not equal to 
("Optional("OnePromise_Tests.OnePromiseTests.SomeError")") - 
```
