### PR TITLE
Change Promise.resolve signature

### DIFF
--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -226,17 +226,17 @@ extension Promise {
     If `value` is a Promise, returns the promise.
     If `value` is not a Promise, returns a promise that is fulfilled with `value`.
     */
-    class func resolve<T>(value: Promise<T>) -> Promise<T> {
+    class func resolve(value: Promise<ValueType>) -> Promise<ValueType> {
         return value
     }
 
-    class func resolve<T>(value: T) -> Promise<T> {
-        return Promise<T> { $0.fulfill(value) }
+    class func resolve(value: ValueType) -> Promise<ValueType> {
+        return Promise<ValueType> { $0.fulfill(value) }
     }
 
     /// Create a promise that is rejected with given error.
-    class func reject(error: NSError) -> Promise<T> {
-        return Promise<T> { $0.reject(error) }
+    class func reject(error: NSError) -> Promise<ValueType> {
+        return Promise<ValueType> { $0.reject(error) }
     }
 }
 

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -452,13 +452,19 @@ extension OnePromiseTests {
 // MARK: resolve and reject
 extension OnePromiseTests {
     func testResolve() {
-        let expectation = self.expectationWithDescription("done")
+        let expectation1 = self.expectationWithDescription("done")
+        let expectation2 = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>.resolve(100)
+        let promise1 = Promise<Int>.resolve(100)
+        let promise2 = Promise.resolve("string value")
 
-        promise.then({
+        promise1.then({
             XCTAssertEqual($0, 100)
-            expectation.fulfill()
+            expectation1.fulfill()
+        })
+        promise2.then({
+            XCTAssertEqual($0, "string value")
+            expectation2.fulfill()
         })
 
         self.waitForExpectationsWithTimeout(1.0, handler: nil)


### PR DESCRIPTION
To use `Promise.resolve()` function, we must write:

``` swift
Promise<Int>.resolve(1000)
```

This patch fixes the issue, now we can write:

``` swift
Promise.resolve(1000)
```
