### PR TITLE
Incorrect closure return type inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 **IMPORTANT: Version 0.y.z is for initial develpment. Anything may change at any time. The public API should not be considered stable.**
 
+## 0.5.0
+
+- Remove `then(nil, onRejected)` syntax to solve type inference problem. You can use `caught(onRejected)` to omit fulfillment handler.
+
 ## 0.4.0
 
 - Performance improvement


### PR DESCRIPTION
To allow `then(nil, onRejected)` syntax, OnePromise has a declaration below:

``` swift
public func then(onFulfilled: (ValueType throws -> T)?, _ onRejected: (NSError -> Void)? = nil) -> Promise<T> {
    ...
}
```

However It causes problem in a case:

``` swift
let _: Promise<Void> = promise1
    .then({
        (_) in  // should be `(_) -> Promise<Int>`, but was compiled as `(_) -> Void`
        return promise2
    })
    .then({
        XCTAssertEqual(i++, 2)
        expectation.fulfill()
    })
```

So I remove `then((T -> T)?, ...)`.
