### PR TITLE
Deprecate Promise#fulfill and Promise#reject

### DIFF
--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -385,7 +385,7 @@ extension Promise {
                     dispatch_semaphore_signal(lock)
                 })
         }
-        
+
         return deferred.promise
     }
 }

--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -388,16 +388,16 @@ extension Promise {
         _ promise2: Promise<U1>)
         -> Promise<(ValueType, U1)>
     {
-        let joinPromise = Promise<(ValueType, U1)>()
+        let (joinPromise, joinFulfill, joinReject) = Promise<(ValueType, U1)>.deferred()
 
         promise1.then(dispatchQueue,
             { (v1) -> Void in
                 promise2.then(dispatchQueue, { (v2) -> Void in
-                    joinPromise.fulfill((v1, v2))
+                    joinFulfill((v1, v2))
                 })
-            }, joinPromise.reject)
+            }, joinReject)
 
-        promise2.caught(dispatchQueue, joinPromise.reject)
+        promise2.caught(dispatchQueue, joinReject)
 
         return joinPromise
     }
@@ -417,19 +417,19 @@ extension Promise {
         _ promise3: Promise<U2>)
         -> Promise<(ValueType, U1, U2)>
     {
-        let joinPromise = Promise<(ValueType, U1, U2)>()
+        let (joinPromise, joinFulfill, joinReject) = Promise<(ValueType, U1, U2)>.deferred()
 
         promise1.then(dispatchQueue,
             { (v1) -> Void in
                 promise2.then(dispatchQueue, { (v2) -> Void in
                     promise3.then(dispatchQueue, { (v3) -> Void in
-                        joinPromise.fulfill((v1, v2, v3))
+                        joinFulfill((v1, v2, v3))
                     })
                 })
-            }, joinPromise.reject)
+            }, joinReject)
 
-        promise2.caught(dispatchQueue, joinPromise.reject)
-        promise3.caught(dispatchQueue, joinPromise.reject)
+        promise2.caught(dispatchQueue, joinReject)
+        promise3.caught(dispatchQueue, joinReject)
 
         return joinPromise
     }

--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -39,6 +39,15 @@ private enum PromiseState<T>: CustomStringConvertible {
     }
 }
 
+/**
+
+From [Promises/A+](https://promisesaplus.com) specification:
+
+>A _promise_ represents the eventual result of an asynchronous operation. The primary way of
+interacting with a promise is through its `then` method, which registers callbacks to receive either
+a promise's value or the reason why promise cannot be fulfilled.
+
+*/
 public class Promise<T> {
 
     public typealias ValueType = T

--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -62,7 +62,8 @@ public class Promise<T> {
     private let mutex = dispatch_semaphore_create(1)
 
     @available(*, deprecated, message="It will be dropped from a future version.")
-    public init() {
+    public convenience init() {
+        self.init({ (_, _) in })
     }
 
     @available(*, deprecated, message="It will be dropped from a future version.")
@@ -77,8 +78,7 @@ public class Promise<T> {
     which can be called to fulfill or reject the created promise.
 
     */
-    public convenience init(_ block: (ValueType -> Void, NSError -> Void) -> Void) {
-        self.init()
+    public init(_ block: (ValueType -> Void, NSError -> Void) -> Void) {
         block(self.doFulfill, self.doReject)
     }
 

--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -61,9 +61,11 @@ public class Promise<T> {
     /// Allow the execution of just one thread from many others.
     private let mutex = dispatch_semaphore_create(1)
 
+    @available(*, deprecated, message="It will be dropped from a future version.")
     public init() {
     }
 
+    @available(*, deprecated, message="It will be dropped from a future version.")
     public convenience init(block: Promise<T> -> Void) {
         self.init()
         block(self)
@@ -164,6 +166,7 @@ public class Promise<T> {
         }
     }
 
+    @available(*, deprecated, message="It will be dropped from a future version. Use initialization block or Promise.deferred instead")
     public func fulfill(value: ValueType) {
         dispatch_semaphore_wait(self.mutex, DISPATCH_TIME_FOREVER)
         do {
@@ -181,6 +184,7 @@ public class Promise<T> {
         dispatch_semaphore_signal(self.mutex)
     }
 
+    @available(*, deprecated, message="It will be dropped from a future version. Use initialization block or Promise.deferred instead")
     public func reject(error: NSError) {
         dispatch_semaphore_wait(self.mutex, DISPATCH_TIME_FOREVER)
         do {

--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -236,18 +236,6 @@ extension Promise {
     - returns:  A Promise which will be resolved with the same fulfillment value or
     rejection reason as receiver.
 
-    ### Limitations
-
-    [Promises/A+](https://promisesaplus.com/#notes) allows `onRejected` returns a value or Promise,
-    or throws error. OnePromise, however, `onRejected` signature is `(NSError) -> Void`.
-    Because of this, we can not implement `finally()` method like
-    [Q](https://github.com/kriskowal/q/wiki/API-Reference#promisefinallycallback).
-
-    ### TODO
-
-    If `callback` returns a promise, the resolution of the returned promise will be delayed until
-    the promise returned from `callback` is finished.
-
     */
     public func finally(dispatchQueue: dispatch_queue_t, _ callback: () -> Void) -> Promise<ValueType> {
         return self.then(dispatchQueue,

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -9,16 +9,16 @@ private let kOnePromiseTestsQueue: dispatch_queue_t = {
     dispatch_queue_set_specific(q, &testQueueTag, &testQueueTag, nil)
 
     return q
-}()
+    }()
 
 class OnePromiseTests: XCTestCase {
 
     func testCreateWithBlock() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise: Promise<Int> = Promise { (promise) in
+        let promise: Promise<Int> = Promise { (fulfill, _) in
             dispatch_async(dispatch_get_main_queue()) {
-                promise.fulfill(1)
+                fulfill(1)
             }
         }
 
@@ -33,9 +33,9 @@ class OnePromiseTests: XCTestCase {
     func testPromiseCallbackReturnsSameTypeAsValueType() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (value:Int) -> Int in
                 return value * 2
             })
@@ -44,7 +44,7 @@ class OnePromiseTests: XCTestCase {
                 expectation.fulfill()
             })
 
-        promise.fulfill(1000)
+        deferred.fulfill(1000)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 }
@@ -54,8 +54,11 @@ extension OnePromiseTests {
     func testTypeInference1() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise1 = Promise<Int>()
-        let promise2 = Promise<Int>()
+        let deferred1 = Promise<Int>.deferred()
+        let deferred2 = Promise<Int>.deferred()
+
+        let promise1 = deferred1.promise
+        let promise2 = deferred2.promise
 
         var i = 0
 
@@ -77,9 +80,9 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise1.fulfill(1)
+        deferred1.fulfill(1)
         dispatch_async(dispatch_get_main_queue()) { () -> Void in
-            promise2.fulfill(2)
+            deferred2.fulfill(2)
         }
 
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
@@ -129,9 +132,9 @@ extension OnePromiseTests {
     func testDispatchQueue() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (i) -> Int in
                 XCTAssertFalse(self.isInTestDispatchQueue())
                 return i * 2
@@ -140,11 +143,9 @@ extension OnePromiseTests {
                 XCTAssertTrue(self.isInTestDispatchQueue())
                 XCTAssertEqual(i, 2000)
 
-                let np = Promise<String>()
-
-                np.fulfill("\(i)")
-
-                return np
+                return Promise<String> { (fulfill, _) in
+                    fulfill("\(i)")
+                }
             })
             .then(kOnePromiseTestsQueue, { (s) in
                 XCTAssertTrue(self.isInTestDispatchQueue())
@@ -153,7 +154,7 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise.fulfill(1000)
+        deferred.fulfill(1000)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 }
@@ -163,13 +164,13 @@ extension OnePromiseTests {
     func testChildPromiseOfPendingPromise() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (i) in
-                Promise<Double> { (p) in
+                Promise<Double> { (fulfill, _) in
                     dispatch_async(dispatch_get_main_queue()) {
-                        p.fulfill(Double(i))
+                        fulfill(Double(i))
                     }
                 }
             })
@@ -179,7 +180,7 @@ extension OnePromiseTests {
             })
 
         dispatch_async(dispatch_get_main_queue()) {
-            promise.fulfill(2)
+            deferred.fulfill(2)
         }
 
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
@@ -188,24 +189,24 @@ extension OnePromiseTests {
     func testChildPromiseOfPendingPromiseToBeRejected() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (i) in
-                Promise<Double> { (p) in
+                Promise<Double> { (fulfill, _) in
                     dispatch_async(dispatch_get_main_queue()) {
-                        p.fulfill(Double(i))
+                        fulfill(Double(i))
                     }
                 }
             })
             .then({ (d) -> Void in
                 XCTFail()
-            }, { (e: NSError) in
-                expectation.fulfill()
+                }, { (e: NSError) in
+                    expectation.fulfill()
             })
 
         dispatch_async(dispatch_get_main_queue()) {
-            promise.reject(self.generateRandomError())
+            deferred.reject(self.generateRandomError())
         }
 
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
@@ -214,14 +215,14 @@ extension OnePromiseTests {
     func testChildPromiseOfFulfilledPromise() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise.fulfill(2)
+        deferred.fulfill(2)
 
-        promise
+        deferred.promise
             .then({ (i) in
-                Promise<Double> { (p) in
-                    p.fulfill(Double(i))
+                Promise<Double> { (fulfill, _) in
+                    fulfill(Double(i))
                 }
             })
             .then({ (d) -> Void in
@@ -249,7 +250,8 @@ extension OnePromiseTests {
         expectations.append(self.expectationWithDescription("4"))
 
         // Promise and callback registration
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
+        let promise  = deferred.promise
 
         promise
             .then(serialQueue, { (value) -> Void in
@@ -266,7 +268,7 @@ extension OnePromiseTests {
             expectations[i++].fulfill()
         })
 
-        promise.fulfill(1000)
+        deferred.fulfill(1000)
 
         promise.then(serialQueue, { (value) -> Void in
             XCTAssertEqual(i, 2)
@@ -279,14 +281,15 @@ extension OnePromiseTests {
     func testOnFulfilledNeverCalledIfAlreadyRejected() {
         let expectation = self.expectationWithDescription("wait")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
+        let promise  = deferred.promise
 
-        promise.reject(self.generateRandomError())
+        deferred.reject(self.generateRandomError())
 
         promise
             .then({ (value) -> Promise<Int> in
                 XCTFail()
-                return Promise<Int>()
+                return Promise<Int>() { (_, _) in }
             })
             .then({ (value) in
                 XCTFail()
@@ -302,9 +305,9 @@ extension OnePromiseTests {
     func testPropagateFulfillToChildPromises() {
         let expectation = self.expectationWithDescription("wait")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .caught({ (e: NSError) in
                 XCTFail()
             })
@@ -313,7 +316,7 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise.fulfill(123)
+        deferred.fulfill(123)
 
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
@@ -335,8 +338,9 @@ extension OnePromiseTests {
         expectations.append(self.expectationWithDescription("4"))
 
         // Promise and callback registration
-        let error   = self.generateRandomError()
-        let promise = Promise<Int>()
+        let error = self.generateRandomError()
+        let deferred = Promise<Int>.deferred()
+        let promise  = deferred.promise
 
         promise
             .caught(serialQueue, { (e: NSError) -> Void in
@@ -353,7 +357,7 @@ extension OnePromiseTests {
             expectations[i++].fulfill()
         })
 
-        promise.reject(error)
+        deferred.reject(error)
 
         promise.caught(serialQueue, { (e: NSError) -> Void in
             XCTAssertEqual(i, 2)
@@ -366,11 +370,11 @@ extension OnePromiseTests {
     func testOnRejectedNeverCalledIfAlreadyFulfilled() {
         let expectation = self.expectationWithDescription("wait")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise.fulfill(1)
+        deferred.fulfill(1)
 
-        promise
+        deferred.promise
             .caught({ (e: NSError) -> Void in
                 XCTFail()
             })
@@ -378,17 +382,17 @@ extension OnePromiseTests {
         dispatch_async(dispatch_get_main_queue()) {
             expectation.fulfill()
         }
-        
+
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
     func testPropagateRejectionToChildPromises() {
         let expectation = self.expectationWithDescription("wait")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
         let error   = self.generateRandomError()
 
-        promise
+        deferred.promise
             .then({ (value) in
 
             })
@@ -397,7 +401,7 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise.reject(error)
+        deferred.reject(error)
 
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
@@ -411,9 +415,9 @@ extension OnePromiseTests {
 
     func testPropagateSwiftErrorType() {
         let expectation = self.expectationWithDescription("wait")
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (i) throws -> Void in
                 throw SomeError.IntError(i)
             })
@@ -422,7 +426,7 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise.fulfill(1)
+        deferred.fulfill(1)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
@@ -430,9 +434,9 @@ extension OnePromiseTests {
         let expectation = self.expectationWithDescription("wait")
 
         let error   = self.generateRandomError()
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (i) throws -> Void in
                 throw error
             })
@@ -441,7 +445,7 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise.fulfill(1)
+        deferred.fulfill(1)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
@@ -449,9 +453,9 @@ extension OnePromiseTests {
         let expectation = self.expectationWithDescription("wait")
 
         let error   = self.generateRandomError()
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (i) throws -> Promise<Int> in
                 throw error
             })
@@ -460,7 +464,7 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise.fulfill(1)
+        deferred.fulfill(1)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
@@ -470,12 +474,12 @@ extension OnePromiseTests {
         let expectation = self.expectationWithDescription("wait")
 
         let error   = self.generateRandomError()
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (i) throws -> Promise<Int> in
-                return Promise<Int> { (promise) in
-                    promise.reject(error)
+                return Promise<Int> { (_, reject) in
+                    reject(error)
                 }
             })
             .caught({ (e: NSError) in
@@ -483,7 +487,7 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise.fulfill(1)
+        deferred.fulfill(1)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 }
@@ -493,12 +497,12 @@ extension OnePromiseTests {
     func testFulfilledStateMustNotTransitionToAnyOtherState() {
         let expectation = self.expectationWithDescription("wait")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise.fulfill(10)
-        promise.fulfill(20)
+        deferred.fulfill(10)
+        deferred.fulfill(20)
 
-        promise.then({ (value) in
+        deferred.promise.then({ (value) in
             XCTAssertEqual(value, 10)
             expectation.fulfill()
         })
@@ -510,17 +514,17 @@ extension OnePromiseTests {
 // MARK: CustomStringConvertible
 extension OnePromiseTests {
     func testDescription() {
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        XCTAssertEqual("\(promise)", "Promise (Pending)")
+        XCTAssertEqual("\(deferred.promise)", "Promise (Pending)")
 
-        promise.fulfill(10)
-        XCTAssertEqual("\(promise)", "Promise (Fulfilled)")
+        deferred.fulfill(10)
+        XCTAssertEqual("\(deferred.promise)", "Promise (Fulfilled)")
 
-        let promise2 = Promise<Int>()
+        let deferred2 = Promise<Int>.deferred()
 
-        promise2.reject(NSError(domain: "", code: -1, userInfo: nil))
-        XCTAssertEqual("\(promise2)", "Promise (Rejected)")
+        deferred2.reject(NSError(domain: "", code: -1, userInfo: nil))
+        XCTAssertEqual("\(deferred2.promise)", "Promise (Rejected)")
     }
 }
 
@@ -546,7 +550,7 @@ extension OnePromiseTests {
     }
 
     func testResolveWithPromise() {
-        let promise1 = Promise<Int>()
+        let promise1 = Promise<Int>.resolve(100)
         let promise2 = Promise<Int>.resolve(promise1)
 
         XCTAssertTrue(promise1 === promise2)
@@ -573,14 +577,14 @@ extension OnePromiseTests {
         let expectation = self.expectationWithDescription("done")
 
         let error   = self.generateRandomError()
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise.caught({
+        deferred.promise.caught({
             XCTAssertEqual($0, error)
             expectation.fulfill()
         })
 
-        promise.reject(error)
+        deferred.reject(error)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
@@ -588,15 +592,16 @@ extension OnePromiseTests {
         let expectation = self.expectationWithDescription("done")
 
         let error   = self.generateRandomError()
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise.caught(kOnePromiseTestsQueue, {
-            XCTAssertTrue(self.isInTestDispatchQueue())
-            XCTAssertEqual($0, error)
-            expectation.fulfill()
-        })
+        deferred.promise
+            .caught(kOnePromiseTestsQueue, {
+                XCTAssertTrue(self.isInTestDispatchQueue())
+                XCTAssertEqual($0, error)
+                expectation.fulfill()
+            })
 
-        promise.reject(error)
+        deferred.reject(error)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 }
@@ -606,49 +611,49 @@ extension OnePromiseTests {
     func testFin() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise.finally({
+        deferred.promise.finally({
             expectation.fulfill()
         })
 
-        promise.fulfill(1)
+        deferred.fulfill(1)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
     func testFinWithDispatchQueue() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise.finally(kOnePromiseTestsQueue, {
+        deferred.promise.finally(kOnePromiseTestsQueue, {
             XCTAssertTrue(self.isInTestDispatchQueue())
             expectation.fulfill()
         })
 
-        promise.fulfill(1)
+        deferred.fulfill(1)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
     func testFinWithRejection() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise.finally({
+        deferred.promise.finally({
             expectation.fulfill()
         })
 
-        promise.reject(self.generateRandomError())
+        deferred.reject(self.generateRandomError())
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
     func testThenFin() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise = Promise<Int>()
+        let deferred = Promise<Int>.deferred()
 
-        promise
+        deferred.promise
             .then({ (_) -> Void in
 
             })
@@ -656,7 +661,7 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        promise.reject(self.generateRandomError())
+        deferred.reject(self.generateRandomError())
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 }
@@ -665,17 +670,19 @@ extension OnePromiseTests {
 extension OnePromiseTests {
     func testAllPromisesFulfilled() {
         var promises: [Promise<Int>] = []
+        var fulfillers: [Int -> Void] = []
 
         for i in 1...10 {
             let subexpectation = self.expectationWithDescription("Promise \(i)")
-            let subpromise = Promise<Int>()
+            let d = Promise<Int>.deferred()
 
-            subpromise
+            d.promise
                 .then({ (_) -> Void in
                     subexpectation.fulfill()
                 })
 
-            promises.append(subpromise)
+            promises.append(d.promise)
+            fulfillers.append(d.fulfill)
         }
 
         let expectation = self.expectationWithDescription("All done")
@@ -689,8 +696,8 @@ extension OnePromiseTests {
                 XCTFail()
             })
 
-        for promise in promises {
-            promise.fulfill(1)
+        for f in fulfillers {
+            f(1)
         }
 
         self.waitForExpectationsWithTimeout(3.0, handler: nil)
@@ -698,9 +705,15 @@ extension OnePromiseTests {
 
     func testAnyPromisesRejected() {
         var promises: [Promise<Int>] = []
+        var fulfillers: [Int -> Void] = []
+        var rejecters: [NSError -> Void] = []
 
         for _ in 1...10 {
-            promises.append(Promise<Int>())
+            let d = Promise<Int>.deferred()
+
+            promises.append(d.promise)
+            fulfillers.append(d.fulfill)
+            rejecters.append(d.reject)
         }
 
         let expectation = self.expectationWithDescription("All done")
@@ -715,13 +728,14 @@ extension OnePromiseTests {
             })
 
         let error = self.generateRandomError()
-        let rejectTarget = promises.popLast()!
 
-        for promise in promises {
-            promise.fulfill(2)
+        fulfillers.popLast()
+
+        for f in fulfillers {
+            f(2)
         }
 
-        rejectTarget.reject(error)
+        rejecters.last!(error)
 
         self.waitForExpectationsWithTimeout(3.0, handler: nil)
     }
@@ -731,8 +745,10 @@ extension OnePromiseTests {
 extension OnePromiseTests {
     // Promise.join/2
     func testJoinedTwoPromisesFulfilled() {
-        let intPromise = Promise<Int>()
-        let strPromise = Promise<String>()
+        let intDeferred = Promise<Int>.deferred()
+        let strDeferred = Promise<String>.deferred()
+        let intPromise  = intDeferred.promise
+        let strPromise  = strDeferred.promise
 
         let expectation1 = self.expectationWithDescription("Int Promise")
         let expectation2 = self.expectationWithDescription("String Promise")
@@ -760,15 +776,18 @@ extension OnePromiseTests {
                 XCTFail()
             })
 
-        intPromise.fulfill(1000)
-        strPromise.fulfill("string value")
+        intDeferred.fulfill(1000)
+        strDeferred.fulfill("string value")
 
         self.waitForExpectationsWithTimeout(3.0, handler: nil)
     }
 
     func testJoinedTwoPromisesRejected() {
-        let intPromise = Promise<Int>()
-        let strPromise = Promise<String>()
+        let intDeferred = Promise<Int>.deferred()
+        let strDeferred = Promise<String>.deferred()
+
+        let intPromise = intDeferred.promise
+        let strPromise = strDeferred.promise
 
         let expectation1 = self.expectationWithDescription("Int Promise")
         let expectation2 = self.expectationWithDescription("String Promise")
@@ -795,17 +814,21 @@ extension OnePromiseTests {
                 expectation.fulfill()
             })
 
-        intPromise.fulfill(1000)
-        strPromise.reject(error)
+        intDeferred.fulfill(1000)
+        strDeferred.reject(error)
 
         self.waitForExpectationsWithTimeout(3.0, handler: nil)
     }
 
     // Promise.join/3
     func testJoinedThreePromisesFulfilled() {
-        let intPromise    = Promise<Int>()
-        let strPromise    = Promise<String>()
-        let doublePromise = Promise<Double>()
+        let intDeferred    = Promise<Int>.deferred()
+        let strDeferred    = Promise<String>.deferred()
+        let doubleDeferred = Promise<Double>.deferred()
+
+        let intPromise    = intDeferred.promise
+        let strPromise    = strDeferred.promise
+        let doublePromise = doubleDeferred.promise
 
         let expectation1 = self.expectationWithDescription("Int Promise")
         let expectation2 = self.expectationWithDescription("String Promise")
@@ -839,9 +862,9 @@ extension OnePromiseTests {
                 XCTFail()
             })
 
-        intPromise.fulfill(1000)
-        strPromise.fulfill("string value")
-        doublePromise.fulfill(2000.0)
+        intDeferred.fulfill(1000)
+        strDeferred.fulfill("string value")
+        doubleDeferred.fulfill(2000.0)
 
         self.waitForExpectationsWithTimeout(3.0, handler: nil)
     }
@@ -849,14 +872,18 @@ extension OnePromiseTests {
     func testJoinedThreePromisesRejected() {
         let error = self.generateRandomError()
 
-        let intPromise    = Promise<Int>()
-        let strPromise    = Promise<String>()
-        let doublePromise = Promise<Double>()
+        let intDeferred    = Promise<Int>.deferred()
+        let strDeferred    = Promise<String>.deferred()
+        let doubleDeferred = Promise<Double>.deferred()
+
+        let intPromise    = intDeferred.promise
+        let strPromise    = strDeferred.promise
+        let doublePromise = doubleDeferred.promise
 
         let expectation1 = self.expectationWithDescription("Int Promise")
         let expectation2 = self.expectationWithDescription("String Promise")
         let expectation3 = self.expectationWithDescription("String Promise")
-
+        
         intPromise
             .then({ (_) -> Void in
                 expectation1.fulfill()
@@ -870,9 +897,9 @@ extension OnePromiseTests {
             .then({ (_) -> Void in
                 expectation3.fulfill()
             })
-
+        
         let expectation = self.expectationWithDescription("All done")
-
+        
         Promise.join(intPromise, strPromise, doublePromise)
             .then(kOnePromiseTestsQueue, { (_, _, _) -> Void in
                 XCTFail()
@@ -882,10 +909,10 @@ extension OnePromiseTests {
                 XCTAssertEqual(e, error)
                 expectation.fulfill()
             })
-
-        intPromise.fulfill(1000)
-        doublePromise.fulfill(2000.0)
-        strPromise.reject(error)
+        
+        intDeferred.fulfill(1000)
+        doubleDeferred.fulfill(2000.0)
+        strDeferred.reject(error)
 
         self.waitForExpectationsWithTimeout(3.0, handler: nil)
     }
@@ -895,10 +922,10 @@ extension OnePromiseTests {
 extension OnePromiseTests {
     private func generateRandomError() -> NSError {
         let code = Int(arc4random_uniform(10001))
-
+        
         return NSError(domain: "test.SomeError", code: code, userInfo: nil)
     }
-
+    
     private func isInTestDispatchQueue() -> Bool {
         return dispatch_get_specific(&testQueueTag) != nil
     }

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -86,6 +86,44 @@ extension OnePromiseTests {
     }
 }
 
+// MARK: Deferred
+extension OnePromiseTests {
+    func testDeferredFulfill() {
+        let expectation = self.expectationWithDescription("done")
+
+        let deferred = Promise<Int>.deferred()
+
+        deferred.promise
+            .then({
+                XCTAssertEqual($0, 199)
+                expectation.fulfill()
+            })
+
+        dispatch_async(dispatch_get_main_queue()) {
+            deferred.fulfill(199)
+        }
+
+        self.waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+
+    func testDeferredReject() {
+        let expectation = self.expectationWithDescription("done")
+
+        let (promise, _, reject) = Promise<Int>.deferred()
+
+        promise
+            .caught({ (_) in
+                expectation.fulfill()
+            })
+
+        dispatch_async(dispatch_get_main_queue()) {
+            reject(self.generateRandomError())
+        }
+
+        self.waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+}
+
 // MARK: Dispatch Queue
 extension OnePromiseTests {
     func testDispatchQueue() {

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -883,7 +883,7 @@ extension OnePromiseTests {
         let expectation1 = self.expectationWithDescription("Int Promise")
         let expectation2 = self.expectationWithDescription("String Promise")
         let expectation3 = self.expectationWithDescription("String Promise")
-        
+
         intPromise
             .then({ (_) -> Void in
                 expectation1.fulfill()
@@ -897,9 +897,9 @@ extension OnePromiseTests {
             .then({ (_) -> Void in
                 expectation3.fulfill()
             })
-        
+
         let expectation = self.expectationWithDescription("All done")
-        
+
         Promise.join(intPromise, strPromise, doublePromise)
             .then(kOnePromiseTestsQueue, { (_, _, _) -> Void in
                 XCTFail()
@@ -909,7 +909,7 @@ extension OnePromiseTests {
                 XCTAssertEqual(e, error)
                 expectation.fulfill()
             })
-        
+
         intDeferred.fulfill(1000)
         doubleDeferred.fulfill(2000.0)
         strDeferred.reject(error)
@@ -922,10 +922,10 @@ extension OnePromiseTests {
 extension OnePromiseTests {
     private func generateRandomError() -> NSError {
         let code = Int(arc4random_uniform(10001))
-        
+
         return NSError(domain: "test.SomeError", code: code, userInfo: nil)
     }
-    
+
     private func isInTestDispatchQueue() -> Bool {
         return dispatch_get_specific(&testQueueTag) != nil
     }


### PR DESCRIPTION
Deprecate `Promise#fulfill(...)` and `Promise#reject(...)` method. Both methods are useful but more on some cases they cause silly problem. Instead of it, more standard constructor will be introduced:

``` swift
return Promise<Int>() { (fulfill, reject) in
    ...
    fulfill(1000) // or reject(error)
}
```

Old school initializers `Promise()` and `Promise({ (promise) in ... })` also be deprecated and dropped in a future version.
### Promise.deferred()

The new API `Promise.deferred()` creates new promise instance and returns its fulfill/reject functions. You can use it instead of deprecated `Promise#fulfill(...)` and `Promise#reject(...)` method.

``` swift
let (promise, fulfill, reject) = Promise<Int>.deferred()

dispatch_async(q, {
    ...
    fulfill(1000) // or reject(error)
})
```

OnePromise philosophy is simplicity and less exported symbols, in favor of this, `Promise.deferred()` returns tuple (anonymous).
