### PR TITLE
Error handling with ErrorType

### DIFF
--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -98,8 +98,13 @@ public class Promise<T> {
     which can be called to fulfill or reject the created promise.
 
     */
-    public init(_ block: (ValueType -> Void, NSError -> Void) -> Void) {
-        block(self.doFulfill, self.doReject)
+    public init(_ block: (ValueType -> Void, NSError -> Void) throws -> Void) {
+        do {
+            try block(self.doFulfill, self.doReject)
+        }
+        catch let error as NSError {
+            self.doReject(error)
+        }
     }
 
     /**
@@ -190,7 +195,8 @@ public class Promise<T> {
             dispatch_async(dispatchQueue, {
                 do {
                     try onFulfilled(value).then(dispatchQueue, nextFulfill, nextReject)
-                } catch let error as NSError {
+                }
+                catch let error as NSError {
                     nextReject(error)
                 }
             })

--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -338,6 +338,11 @@ extension Promise {
         }
     }
 
+    /// Same as `reject(err as NSError)`
+    public class func reject(error: ErrorType) -> Promise<ValueType> {
+        return reject(error as NSError)
+    }
+
     // -----------------------------------------------------------------
     // MARK: caught
     // -----------------------------------------------------------------

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -14,6 +14,7 @@ private let kOnePromiseTestsQueue: dispatch_queue_t = {
 
 enum ErrorWithValue: ErrorType {
     case IntError(Int)
+    case StrError(String)
 }
 
 class OnePromiseTests: XCTestCase {
@@ -617,6 +618,25 @@ extension OnePromiseTests {
 
         promise.caught({
             XCTAssertEqual($0, error)
+            expectation.fulfill()
+        })
+
+        self.waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+
+    func testRejectedWithErrorTypePromise() {
+        let expectation = self.expectationWithDescription("done")
+
+        let promise = Promise<Int>.reject(ErrorWithValue.StrError("panic!"))
+
+        promise.caught({ (err: ErrorWithValue) in
+            if case .StrError(let str) = err {
+                XCTAssertEqual(str, "panic!")
+            }
+            else {
+                XCTFail()
+            }
+
             expectation.fulfill()
         })
 

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -427,7 +427,7 @@ extension OnePromiseTests {
     }
 
     func testOnRejectWithCustomErrorType() {
-        let expectation = self.expectationWithDescription("wait")
+        let expectation = self.expectationWithDescription("done")
         let deferred = Promise<Int>.deferred()
 
         deferred.promise
@@ -439,6 +439,23 @@ extension OnePromiseTests {
             })
 
         deferred.reject(ErrorWithValue.IntError(2000) as NSError)
+        self.waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+
+    func testOnRejectWithCustomErrorTypeThenFulfill() {
+        let expectation = self.expectationWithDescription("done")
+        let deferred = Promise<Int>.deferred()
+
+        deferred.promise
+            .caught({ (e: ErrorWithValue) in
+                XCTFail()
+            })
+            .then({ (value) -> Void in
+                XCTAssertEqual(value, 2000)
+                expectation.fulfill()
+            })
+
+        deferred.fulfill(2000)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 }

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -425,6 +425,22 @@ extension OnePromiseTests {
 
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
+
+    func testOnRejectWithCustomErrorType() {
+        let expectation = self.expectationWithDescription("wait")
+        let deferred = Promise<Int>.deferred()
+
+        deferred.promise
+            .caught({ (e: ErrorWithValue) in
+                if case .IntError(let value) = e {
+                    XCTAssertEqual(value, 2000)
+                }
+                expectation.fulfill()
+            })
+
+        deferred.reject(ErrorWithValue.IntError(2000) as NSError)
+        self.waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
 }
 
 // MARK: onRejected: Error propagation

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -12,6 +12,10 @@ private let kOnePromiseTestsQueue: dispatch_queue_t = {
     return q
 }()
 
+enum ErrorWithValue: ErrorType {
+    case IntError(Int)
+}
+
 class OnePromiseTests: XCTestCase {
 
     func testCreateWithBlock() {
@@ -46,6 +50,21 @@ class OnePromiseTests: XCTestCase {
             })
 
         deferred.fulfill(1000)
+        self.waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
+
+    func testCreateWithBlockThrows() {
+        let expectation = self.expectationWithDescription("done")
+
+        let promise: Promise<Void> = Promise<Void>({ (_, _) throws in
+            throw ErrorWithValue.IntError(1000)
+        })
+
+        promise.caught({ (error) -> Void in
+            XCTAssert(error.domain.hasSuffix(".ErrorWithValue"))
+            expectation.fulfill()
+        })
+
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 }

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -28,8 +28,8 @@ class OnePromiseTests: XCTestCase {
             }
         }
 
-        promise.then({ (value) -> Void in
-            XCTAssertEqual(value, 1)
+        promise.then({
+            XCTAssertEqual($0, 1)
             expectation.fulfill()
         })
 
@@ -42,11 +42,11 @@ class OnePromiseTests: XCTestCase {
         let deferred = Promise<Int>.deferred()
 
         deferred.promise
-            .then({ (value:Int) -> Int in
-                return value * 2
+            .then({
+                return $0 * 2
             })
-            .then({ (value:Int) in
-                XCTAssertEqual(value, 2000)
+            .then({
+                XCTAssertEqual($0, 2000)
                 expectation.fulfill()
             })
 
@@ -57,12 +57,12 @@ class OnePromiseTests: XCTestCase {
     func testCreateWithBlockThrows() {
         let expectation = self.expectationWithDescription("done")
 
-        let promise: Promise<Void> = Promise<Void>({ (_, _) throws in
+        let promise = Promise<Void>({ (_, _) throws in
             throw ErrorWithValue.IntError(1000)
         })
 
-        promise.caught({ (error) -> Void in
-            XCTAssert(error.domain.hasSuffix(".ErrorWithValue"))
+        promise.caught({
+            XCTAssert($0.domain.hasSuffix(".ErrorWithValue"))
             expectation.fulfill()
         })
 


### PR DESCRIPTION
`reject` and `.caught` supports the `ErrorType` protocol.

``` swift
enum VendingMachineError: ErrorType {
    case InvalidSelection
    case InsufficientFunds(coinsNeeded: Int)
    case OutOfStock
}

let promise = Promise.reject(VendingMachineError.InsufficientFunds(5))

promise.caught({ (err:VendingMachineError) in
    if case .InsufficientFunds(let coins) = err {
        ...
    }
})
```

These extension simply converts `ErrorType` to `NSError`.
