### PR TITLE
Fix Promise.all() fulfillment value ordering

### DIFF
--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -431,6 +431,8 @@ extension Promise {
     The returned promise's fulfillment value is array of `T`.
     If any promise is rejected, the returned promise is rejected.
 
+    Returns array with fulfillment values at respective positions to the original array.
+
     */
     public class func all(dispatchQueue: dispatch_queue_t, _ promises: [Promise<ValueType>]) -> Promise<[ValueType]> {
         let deferred = Promise<[ValueType]>.deferred()

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -677,6 +677,26 @@ extension OnePromiseTests {
         deferred.reject(error)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
+
+    func testIgnoreErrorInCaughtHandler() {
+        let expectation1 = self.expectationWithDescription("done 1")
+        let expectation2 = self.expectationWithDescription("done 2")
+
+        let promise = Promise<Int> { (_, reject) in
+            reject(self.generateRandomError())
+        }
+
+        // The #1 arg in error handler can be omitted.
+        promise
+            .then({ (_) in }, { (_) in
+                expectation1.fulfill()
+            })
+            .caught({ (_) in
+                expectation2.fulfill()
+            })
+
+        self.waitForExpectationsWithTimeout(1.0, handler: nil)
+    }
 }
 
 // MARK: finally


### PR DESCRIPTION
`Promise.all` should returns array with fulfillment values at respective positions to the original array.
