### PR TITLE
Improve .finally

### DIFF
--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -392,8 +392,11 @@ extension Promise {
     // -----------------------------------------------------------------
     /**
 
-    `finally` will be invoked regardless of the promise is fulfilled or rejected, allows you to
+    `.finally` will be invoked regardless of the promise is fulfilled or rejected, allows you to
     observe either fulfillment or rejection of the promise.
+
+    If the callback passed to `.finally` returns a promise, the resolution of the returned promise
+    will be delayed until the promise returned from callback is resolved.
 
     - parameter callback
     - returns:  A Promise which will be resolved with the same fulfillment value or
@@ -416,6 +419,16 @@ extension Promise {
         return finally(dispatch_get_main_queue(), callback)
     }
 
+    /**
+
+    If the callback passed to `.finally` returns a promise, the resolution of the returned promise
+    will be delayed until the promise returned from callback is resolved.
+
+    - parameter callback returns a promise
+    - returns:  A Promise which will be resolved with the same fulfillment value or
+    rejection reason as receiver.
+
+    */
     public func finally<U>(dispatchQueue: dispatch_queue_t, _ callback: () -> Promise<U>) -> Promise<ValueType> {
         let deferred = Promise<ValueType>.deferred()
 
@@ -443,6 +456,8 @@ extension Promise {
 
         return deferred.promise
     }
+
+    /// Same as `finally(dispatch_get_main_queue(), callback)`
     public func finally<U>(callback: () -> Promise<U>) -> Promise<ValueType> {
         return finally(dispatch_get_main_queue(), callback)
     }

--- a/OnePromise.swift
+++ b/OnePromise.swift
@@ -406,9 +406,9 @@ extension Promise {
                 callback()
                 return value
             },
-            { (error: NSError) in
+            { (_) in
                 callback()
-        })
+            })
     }
 
     /// Same as `finally(dispatch_get_main_queue(), callback)`

--- a/OnePromiseTests.swift
+++ b/OnePromiseTests.swift
@@ -701,20 +701,26 @@ extension OnePromiseTests {
 
 // MARK: finally
 extension OnePromiseTests {
-    func testFin() {
-        let expectation = self.expectationWithDescription("done")
+    func testFinally() {
+        let expectation1 = self.expectationWithDescription("done 1")
+        let expectation2 = self.expectationWithDescription("done 2")
 
         let deferred = Promise<Int>.deferred()
 
-        deferred.promise.finally({
-            expectation.fulfill()
-        })
+        deferred.promise
+            .finally({
+                expectation1.fulfill()
+            })
+            .then({ (n) in
+                expectation2.fulfill()
+                XCTAssertEqual(n, 555)
+            })
 
-        deferred.fulfill(1)
+        deferred.fulfill(555)
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
-    func testFinWithDispatchQueue() {
+    func testFinallyWithDispatchQueue() {
         let expectation = self.expectationWithDescription("done")
 
         let deferred = Promise<Int>.deferred()
@@ -728,7 +734,7 @@ extension OnePromiseTests {
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
-    func testFinWithRejection() {
+    func testFinallyWithRejection() {
         let expectation = self.expectationWithDescription("done")
 
         let deferred = Promise<Int>.deferred()
@@ -741,7 +747,7 @@ extension OnePromiseTests {
         self.waitForExpectationsWithTimeout(1.0, handler: nil)
     }
 
-    func testThenFin() {
+    func testThenFinally() {
         let expectation = self.expectationWithDescription("done")
 
         let deferred = Promise<Int>.deferred()


### PR DESCRIPTION
If the callback passed to `.finally` returns a promise, the resolution of the returned promise will be delayed until the promise returned from callback is resolved.
